### PR TITLE
Added deprecation notice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
+## :warning: Deprecated :warning:
 
-
-
+###  Please find 1.0 updates in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch.
 
 # Griddle Remote Plugin (BETA)
 


### PR DESCRIPTION
Adds note to indicate that progress is now happening in the [1.0-combined](https://github.com/GriddleGriddle/Griddle/tree/1.0-combined) branch on the main `griddle` repo.